### PR TITLE
include css output in the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,19 @@
   "module": "./dist/vue-components.js",
   "types": "./dist_types/index.d.ts",
   "exports": {
-    "import": "./dist/vue-components.js",
-    "require": "./dist/vue-components.umd.js"
+    ".": {
+      "import": {
+        "types": "./dist_types/index.d.ts",
+        "default": "./dist/vue-components.js"
+      },
+      "require": {
+        "types": "./dist_types/index.d.ts",
+        "default": "./dist/vue-components.umd.js"
+      }
+    },
+    "./style.css": {
+      "import": "./dist/style.css"
+    }
   },
   "scripts": {
     "start": "npm run storybook",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "./style.css";
+
 // Composables
 export { default as useAnimatedNumber } from "./composables/animatedNumber";
 

--- a/tsconfig.compile.json
+++ b/tsconfig.compile.json
@@ -15,6 +15,9 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": [
+      "vite/client"
+    ]
   }
 }


### PR DESCRIPTION
Tested in local vite project, working by adding in project css: 
`@import "@bcc-code/vue-components/style.css";`

Added BccButton as Vue component by importing
`import { BccButton } from '@bcc-code/vue-components'`