### PR TITLE
Fixes toggle behaviour on smaller screens

### DIFF
--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -1,10 +1,10 @@
 @layer components {
     .bcc-toggle {
-        @apply relative inline-flex cursor-pointer items-center gap-x-3;
+        @apply relative inline-flex cursor-pointer gap-x-3;
     }
 
     .bcc-toggle .bcc-toggle-input {
-        @apply h-6 w-11 cursor-pointer appearance-none rounded-full bg-neutral-200 transition-all duration-100 checked:bg-silver-tree-600 focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:checked:ring-silver-tree-900;
+        @apply h-6 w-11 flex-none cursor-pointer appearance-none rounded-full bg-neutral-200 transition-all duration-100 checked:bg-silver-tree-600 focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:checked:ring-silver-tree-900;
     }
 
     .bcc-toggle.bcc-toggle-was-toggled .bcc-toggle-input {
@@ -28,7 +28,7 @@
     }
 
     .bcc-toggle .bcc-toggle-label {
-        @apply text-sm text-secondary;
+        @apply text-sm text-secondary self-center;
     }
 
     .bcc-toggle .bcc-toggle-input:disabled ~ .bcc-toggle-label {


### PR DESCRIPTION
Fixes a couple problems.

- When the label text had to wrap to a new line, the circle and the background got misaligned. Now the label is centered when one line but new lines do not affect toggle position.
- On smaller screens the toggle background shrinks to accommodate for space. Now the toggle size stays fixed.