### PR TITLE
Only deploy Storybook on release

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,9 +2,8 @@ name: Deploy Storybook
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:


### PR DESCRIPTION
This prevents the production Storybook from being updated with unreleased WIP changes from main
